### PR TITLE
fix: workflow permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Roma7-7-7/todoist-notifier/security/code-scanning/1](https://github.com/Roma7-7-7/todoist-notifier/security/code-scanning/1)

To fix the problem, explicitly set the minimal necessary permissions for the job by adding a `permissions` block to the workflow. The best approach is to add permissions at the job level (directly under the `build:` job) or at the root of the workflow before the `jobs:` block. Since there’s only one job, either location works; using the job level is slightly more explicit. For this workflow (which only needs to read code), the minimal permissions required are `contents: read`. Only the `.github/workflows/build.yaml` file needs editing by adding:

```yaml
permissions:
  contents: read
```

directly under the `build:` block and above the `runs-on:` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
